### PR TITLE
Enforce license headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 SDL (rocrisan@sdl.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -47,6 +64,32 @@
 					<stagingProfileId>${staingProfileId}</stagingProfileId>
 				</configuration>
 			</plugin>
+                        <plugin>
+                                <groupId>com.mycila</groupId>
+                                <artifactId>license-maven-plugin</artifactId>
+                                <version>2.8</version>
+                                <configuration>
+                                        <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                                        <properties>
+                                                <owner>${project.organization.name}</owner>
+                                                <email>rocrisan@sdl.com</email>
+                                        </properties>
+                                        <excludes>
+                                                <exclude>README</exclude>
+                                                <exclude>LICENSE.txt</exclude>
+                                                <exclude>NOTICE</exclude>
+                                                <exclude>src/test/resources/**</exclude>
+                                                <exclude>src/main/resources/**</exclude>
+                                        </excludes>
+                                </configuration>
+                                <executions>
+                                        <execution>
+                                                <goals>
+                                                        <goal>check</goal>
+                                                </goals>
+                                        </execution>
+                                </executions>
+                        </plugin>
 		</plugins>
 	</build>
 

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+#
+# Copyright (C) 2015 SDL (rocrisan@sdl.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 ###
 ### A bash script to simplify Maven releases.


### PR DESCRIPTION
Having a license on the main project is important, but to avoid issues when people just copy out files a brief license template should be applied to source files as well. 

This PR just uses the maven license plugin to enforce a basic header, but I think this needs some work:
1. The owner email address looks like it should be changed to a non-person-bound alias
2. There should be guidelines whether projects using this parent can change the organization (embeddable-rest-server does!), which might require then changes to the email as well.

Potentially it might make sense to use a custom template to avoid at least the email issue, but check the Apache license FAQ first!

(Disclaimer: IANAL.)

FWIW: when the plugin complains about missing headers, you can quickly update them by running `mvn license:format`.
